### PR TITLE
0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.2.1] - 2018-08-26
+### Added
+- Styling for Editor Widgets in both Night and Electric
+- `this` keyword styling for TypeScript
+
+### Changed
+- Function names are no longer orange since we cannot scope to only declarations (See https://github.com/Microsoft/vscode-textmate/issues/52) :/
+
 ## [0.2.0] - 2018-08-26
 ### Added
 - Outrun Night theme. This is a less-intense version of the original Outrun theme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.2.0] - 2018-08-26
+### Added
+- Outrun Night theme. This is a less-intense version of the original Outrun theme
+- Outrun Electric theme. This is the original, high-contrast Outrun theme
+
+### Changed
+- Theme colors have been completely re-worked from the ground up. Editor features have been refined. Some features may be missing and will be implemented as noticed. Thank you for your patience :)
+
+### Removed
+- Outrun theme. The original Outrun theme has been split into Outrun Night and Outrun Electric. Choose one depending on your preferences.
+
 ## [0.1.3] - 2018-07-02
 ### Changed
 - Changed Marketplace banner theme to `dark` even though docs reference this as the "font color". :/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "outrun",
   "displayName": "Outrun",
   "description": "A theme for VS Code inspired by the colors, style, and culture of the synthwave music scene.",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "publisher": "samrapdev",
   "repository": "https://github.com/samrap/outrun-theme-vscode",
   "homepage": "https://outruntheme.com",

--- a/themes/outrun-electric-color-theme.json
+++ b/themes/outrun-electric-color-theme.json
@@ -163,6 +163,7 @@
             "name": "This, Super JS/PHP",
             "scope": [
                 "variable.language.this.js",
+                "variable.language.this.ts",
                 "variable.language.super.js",
                 "variable.language.this.php"
             ],

--- a/themes/outrun-electric-color-theme.json
+++ b/themes/outrun-electric-color-theme.json
@@ -95,7 +95,7 @@
         },
         {
             "name": "Function name",
-            "scope": "entity.name.function",
+            "scope": "entity.name.function - meta.function-call",
             "settings": {
                 "fontStyle": "",
                 "foreground": "#ff9b50"

--- a/themes/outrun-electric-color-theme.json
+++ b/themes/outrun-electric-color-theme.json
@@ -492,6 +492,12 @@
         "editor.wordHighlightBackground":"#ffffff22",
         "editor.wordHighlightStrongBackground":"#42c6ff63",
         "editor.lineHighlightBackground": "#0c0a20",
+
+        // Editor Widget Colors
+        "editorWidget.background":"#3b4167",
+        "editorWidget.border":"#3b4167",
+        "editorHoverWidget.background": "#3b4167",
+        "editorHoverWidget.border": "#3b4167",
   
         // Editor Groups & Tabs
         "editorGroup.dropBackground": "#7984D1",

--- a/themes/outrun-night-color-theme.json
+++ b/themes/outrun-night-color-theme.json
@@ -493,6 +493,12 @@
       "editor.wordHighlightStrongBackground":"#42c6ff63",
       "editor.lineHighlightBackground": "#161130",
 
+      // Editor Widget Colors
+      "editorWidget.background":"#484f7d",
+      "editorWidget.border":"#484f7d",
+      "editorHoverWidget.background": "#3b4167",
+      "editorHoverWidget.border": "#3b4167",
+
       // Editor Groups & Tabs
       "editorGroup.dropBackground": "#7984D1",
       "editorGroupHeader.noTabsBackground": "#0c0a20",


### PR DESCRIPTION
### Added
- Styling for Editor Widgets in both Night and Electric
- `this` keyword styling for TypeScript

### Changed
- Function names are no longer orange since we cannot scope to only declarations (See https://github.com/Microsoft/vscode-textmate/issues/52) :/