### PR TITLE
Added matching color for menu

### DIFF
--- a/themes/outrun-electric-color-theme.json
+++ b/themes/outrun-electric-color-theme.json
@@ -605,5 +605,8 @@
         "terminal.ansiBrightMagenta":"#ff2afc",
         "terminal.ansiBrightCyan":"#42c6ff",
         "terminal.ansiBrightWhite":"#f4f6f9",
+        
+        // Menu Colors
+        "menu.background":"#070612"
     }
   }


### PR DESCRIPTION
Added #070612 as menu background color to match the outrun theme overwriting the default color.